### PR TITLE
fix(initClient) Using NewClient() function

### DIFF
--- a/hiprus.go
+++ b/hiprus.go
@@ -60,7 +60,8 @@ func (hh *HiprusHook) Fire(e *logrus.Entry) error {
 }
 
 func (hh *HiprusHook) initClient() error {
-	hh.c = &hipchat.Client{hh.AuthToken}
+	c := hipchat.NewClient(hh.AuthToken)
+	hh.c = &c
 
 	if hh.Username == "" {
 		hh.Username = "HipRus"


### PR DESCRIPTION
initClient() throws:

```
./hiprus.go:63: too few values in struct initializer
```

Client struct (from andybons/hipchat) now has additionals fields (BaseURL) so
previous struct Client declaration won't work anymore.
