### PR TITLE
Breaking change in tbruyelle/hipchat-go causes compile error

### DIFF
--- a/hiprus.go
+++ b/hiprus.go
@@ -9,13 +9,13 @@ import (
 )
 
 const (
-	VERSION     = "2.0.0"
-	ColorYellow = "yellow"
-	ColorRed    = "red"
-	ColorGreen  = "green"
-	ColorPurple = "purple"
-	ColorGray   = "gray"
-	ColorRandom = "random"
+	VERSION                   = "2.0.0"
+	ColorYellow hipchat.Color = "yellow"
+	ColorRed    hipchat.Color = "red"
+	ColorGreen  hipchat.Color = "green"
+	ColorPurple hipchat.Color = "purple"
+	ColorGray   hipchat.Color = "gray"
+	ColorRandom hipchat.Color = "random"
 )
 
 // HiprusHook is a logrus Hook for dispatching messages to the specified
@@ -47,7 +47,7 @@ func (hh *HiprusHook) Fire(e *logrus.Entry) error {
 		}
 	}
 
-	color := ""
+	var color hipchat.Color
 	notify := false
 	switch e.Level {
 	case logrus.DebugLevel:


### PR DESCRIPTION
[This commit in tbruyelle/hipchat-go](https://github.com/tbruyelle/hipchat-go/commit/c69a7ce6be5e68cd98490630801b87bce93e0d87) introduced a breaking change that causes a compilation error in hiprus. 

Type NotificationRequest now requires the `Color` field to be of type hipchat.Color rather than string.
