### PR TITLE
Close hipchat TCP connection

### DIFF
--- a/hiprus.go
+++ b/hiprus.go
@@ -62,13 +62,17 @@ func (hh *HiprusHook) Fire(e *logrus.Entry) error {
 		notify = true
 	}
 
-	_, err := hh.c.Room.Notification(hh.RoomName, &hipchat.NotificationRequest{
+	response, err := hh.c.Room.Notification(hh.RoomName, &hipchat.NotificationRequest{
 		From:          hh.Username,
 		Message:       e.Message,
 		MessageFormat: "text",
 		Notify:        notify,
 		Color:         color,
 	})
+	
+	if err == nil {
+		response.Body.Close()
+	}
 
 	return err
 }

--- a/hiprus.go
+++ b/hiprus.go
@@ -71,7 +71,7 @@ func (hh *HiprusHook) Fire(e *logrus.Entry) error {
 	})
 	
 	if err == nil {
-		response.Body.Close()
+		_ = response.Body.Close()
 	}
 
 	return err


### PR DESCRIPTION
Client must close response body to end connection. 
Without this connection is hang. For daemon usage it quickly saturate all file descriptions.